### PR TITLE
Make Executor::compile public.

### DIFF
--- a/lib/MtHaml/Support/Php/Executor.php
+++ b/lib/MtHaml/Support/Php/Executor.php
@@ -34,7 +34,7 @@ class Executor
      */
     public function display($file, array $variables)
     {
-        $fun = $this->compileFile($file);
+        $fun = $this->compile($file);
         $fun($variables);
     }
 
@@ -59,7 +59,7 @@ class Executor
         return ob_get_clean();
     }
 
-    private function compileFile($file)
+    public function compile($file)
     {
         if (!file_exists($file)) {
             throw new Exception(sprintf(


### PR DESCRIPTION
rename Executor::compileFile as compile and make it public so it can be used to precompile MtHaml templates, ie: for deploying to GAE.
